### PR TITLE
1.21+ fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /run/
+/build
+/.idea
+/.gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ paper_plugin=false
 # Maven Group
 plugin_main=com.github.ipecter.rtustudio.stg.SwingThroughGrass
 # Plugin version
-plugin_version=1.1.4
+plugin_version=1.1.5
 # Plugin author
 plugin_author=IPECTER
 # RSFramework version

--- a/src/main/java/com/github/ipecter/rtustudio/stg/listener/PlayerInteract.java
+++ b/src/main/java/com/github/ipecter/rtustudio/stg/listener/PlayerInteract.java
@@ -6,7 +6,6 @@ import kr.rtuserver.framework.bukkit.api.listener.RSListener;
 import kr.rtuserver.framework.bukkit.api.utility.platform.MinecraftVersion;
 import org.bukkit.FluidCollisionMode;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -20,9 +19,12 @@ public class PlayerInteract extends RSListener<SwingThroughGrass> {
 
     private final boolean isPaper = MinecraftVersion.isPaper();
 
+    private final boolean newerVersion;
+
     public PlayerInteract(SwingThroughGrass plugin) {
         super(plugin);
         this.blockConfig = plugin.getBlockConfig();
+        this.newerVersion = MinecraftVersion.isSupport("1.21");
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -54,7 +56,7 @@ public class PlayerInteract extends RSListener<SwingThroughGrass> {
             }
 
             if (result != null && result.getHitEntity() != null) {
-                PlayerInteractEvent event = new PlayerInteractEvent(e.getPlayer(), e.getAction(), e.getItem(), null, BlockFace.SOUTH, e.getHand(), result.getHitPosition().toLocation(player.getWorld()));
+                PlayerInteractEvent event = PlayerInteractEventFactory.create(newerVersion, e, result, player);
                 if (event.callEvent()) player.attack(result.getHitEntity());
                 if (!blockConfig.isDestroy()) e.setCancelled(true);
             }

--- a/src/main/java/com/github/ipecter/rtustudio/stg/listener/PlayerInteractEventFactory.java
+++ b/src/main/java/com/github/ipecter/rtustudio/stg/listener/PlayerInteractEventFactory.java
@@ -1,0 +1,66 @@
+package com.github.ipecter.rtustudio.stg.listener;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.RayTraceResult;
+import org.bukkit.util.Vector;
+import org.bukkit.Location;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class PlayerInteractEventFactory {
+
+    private static Constructor<?> constructor;
+
+    static {
+        try {
+            Class<?> clazz = PlayerInteractEvent.class;
+            Class<?>[] newerParams = new Class<?>[] {
+                    Player.class,
+                    Action.class,
+                    ItemStack.class,
+                    Block.class,
+                    BlockFace.class,
+                    EquipmentSlot.class,
+                    Vector.class
+            };
+            constructor = clazz.getConstructor(newerParams);
+        } catch (NoSuchMethodException ignored) {
+            Class<?> clazz = PlayerInteractEvent.class;
+            try {
+                Class<?>[] olderParams = new Class<?>[] {
+                        Player.class,
+                        Action.class,
+                        ItemStack.class,
+                        Block.class,
+                        BlockFace.class,
+                        EquipmentSlot.class,
+                        Location.class
+                };
+                constructor = clazz.getConstructor(olderParams);
+            } catch (NoSuchMethodException exception) {
+                exception.printStackTrace();
+            }
+        }
+    }
+
+    public static PlayerInteractEvent create(boolean newerVersion, PlayerInteractEvent e, RayTraceResult result, Player player) {
+        try {
+            Object[] params;
+            if (newerVersion) {
+                params = new Object[]{e.getPlayer(), Action.LEFT_CLICK_AIR, e.getItem(), null, BlockFace.SOUTH, e.getHand(), result.getHitPosition()};
+            } else {
+                params = new Object[]{e.getPlayer(), Action.LEFT_CLICK_AIR, e.getItem(), null, BlockFace.SOUTH, e.getHand(), result.getHitPosition().toLocation(player.getWorld())};
+            }
+            return (PlayerInteractEvent) constructor.newInstance(params);
+        } catch (IllegalAccessException | InvocationTargetException | InstantiationException ex) {
+            ex.printStackTrace();
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
On newer versions, constructor PlayerInteractEvent(Player, Action, ItemStack, Block, BlockFace, EquipmentSlot, Location) is no longer valid, as Location was replaced by Vector. This PR fixes Errors such as this one:

<details>
  <summary>java.lang.NoSuchMethodError</summary>
 
```
[19:45:41 ERROR]: Could not pass event PlayerInteractEvent to SwingThroughGrass v1.1.4
java.lang.NoSuchMethodError: 'void org.bukkit.event.player.PlayerInteractEvent.<init>(org.bukkit.entity.Player, org.bukkit.event.block.Action, org.bukkit.inventory.ItemStack, org.bukkit.block.Block, org.bukkit.block.BlockFace, org.bukkit.inventory.EquipmentSlot, org.bukkit.Location)'
        at SwingThroughGrass-1.1.4.jar/com.github.ipecter.rtustudio.stg.listener.PlayerInteract.onSwing(PlayerInteract.java:57) ~[SwingThroughGrass-1.1.4.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.4-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:603) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:559) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:554) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.level.ServerPlayerGameMode.handleBlockBreakAction(ServerPlayerGameMode.java:181) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handlePlayerAction(ServerGamePacketListenerImpl.java:1855) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:51) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.network.protocol.game.ServerboundPlayerActionPacket.handle(ServerboundPlayerActionPacket.java:10) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:29) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:155) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1448) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:176) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:129) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1428) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1422) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.util.thread.BlockableEventLoop.runAllTasks(BlockableEventLoop.java:118) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1561) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1251) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310) ~[paper-1.21.4.jar:1.21.4-225-0767902]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```
</details>

while still maintaining backwards compatibility with versions 1.20.6 and lower.